### PR TITLE
Fix typo in the atlassian name for few resources

### DIFF
--- a/components/general/app-gateway.tf
+++ b/components/general/app-gateway.tf
@@ -1,6 +1,6 @@
 resource "azurerm_application_gateway" "ag" {
 
-  name                = "atlasssian-${var.env}-app-gateway"
+  name                = "atlassian-${var.env}-app-gateway"
   resource_group_name = azurerm_resource_group.atlassian_rg.name
   location            = var.location
   tags                = module.ctags.common_tags
@@ -152,7 +152,7 @@ resource "azurerm_application_gateway" "ag" {
 
 
 resource "azurerm_user_assigned_identity" "identity" {
-  name                = "atlasssian-${var.env}-app-gateway-identity"
+  name                = "atlassian-${var.env}-app-gateway-identity"
   resource_group_name = azurerm_resource_group.atlassian_rg.name
   location            = var.location
 
@@ -161,7 +161,7 @@ resource "azurerm_user_assigned_identity" "identity" {
 
 resource "azurerm_role_assignment" "identity" {
   principal_id = azurerm_user_assigned_identity.identity.principal_id
-  scope        = azurerm_key_vault.atlasssian_kv.id
+  scope        = azurerm_key_vault.atlassian_kv.id
 
   role_definition_name = "Key Vault Secrets User"
 }

--- a/components/general/db.tf
+++ b/components/general/db.tf
@@ -1,11 +1,11 @@
 data "azurerm_key_vault_secret" "POSTGRES-SINGLE-SERVER-PASS" {
   name         = "${var.env}-POSTGRES-SINGLE-SERVER-PASS"
-  key_vault_id = azurerm_key_vault.atlasssian_kv.id
+  key_vault_id = azurerm_key_vault.atlassian_kv.id
 }
 
 data "azurerm_key_vault_secret" "POSTGRES-SINGLE-SERVER-USER" {
   name         = "${var.env}-POSTGRES-SINGLE-SERVER-USER"
-  key_vault_id = azurerm_key_vault.atlasssian_kv.id
+  key_vault_id = azurerm_key_vault.atlassian_kv.id
 }
 
 resource "azurerm_postgresql_server" "atlassian-server" {

--- a/components/general/keyvault.tf
+++ b/components/general/keyvault.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
-resource "azurerm_key_vault" "atlasssian_kv" {
-  name                     = "atlasssian-${var.env}-kv"
+resource "azurerm_key_vault" "atlassian_kv" {
+  name                     = "atlassian-${var.env}-kv"
   resource_group_name      = azurerm_resource_group.atlassian_rg.name
   location                 = var.location
   sku_name                 = "standard"
@@ -88,4 +88,9 @@ resource "azurerm_key_vault" "atlasssian_kv" {
   ]
 
   tags = module.ctags.common_tags
+}
+
+moved {
+  from = azurerm_key_vault.atlasssian_kv
+  to   = azurerm_key_vault.atlassian_kv
 }

--- a/components/general/keyvault.tf
+++ b/components/general/keyvault.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_key_vault" "atlassian_kv" {
-  name                     = "atlassian-${var.env}-kv"
+  name                     = "atlasssian-${var.env}-kv"
   resource_group_name      = azurerm_resource_group.atlassian_rg.name
   location                 = var.location
   sku_name                 = "standard"

--- a/components/general/public-ip.tf
+++ b/components/general/public-ip.tf
@@ -1,5 +1,5 @@
 resource "azurerm_public_ip" "app_gw" {
-  name                = "atlasssian-${var.env}-public-ip"
+  name                = "atlassian-${var.env}-public-ip"
   location            = var.location
   resource_group_name = azurerm_resource_group.atlassian_rg.name
   sku                 = "Standard"


### PR DESCRIPTION
Fixing typo in the Atlassian name.  It is expected that its going to re-deploy the resources which is fine.