### PR TITLE
Added NSG rule to allow us to stop the DB connection 

### DIFF
--- a/environments/nonprod/nonprod.tfvars
+++ b/environments/nonprod/nonprod.tfvars
@@ -128,6 +128,17 @@ network_security_groups = {
         source_address_prefix      = "*"
         destination_address_prefix = "*"
       }
+      "postgres_outbound" = {
+        name_override              = "postgres_outbound"
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "5432"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+      }
     }
   }
   atlassian-int-subnet-dat-nsg = {
@@ -186,6 +197,17 @@ network_security_groups = {
         source_port_range          = "*"
         destination_port_range     = "22"
         source_address_prefix      = "10.99.72.0/21"
+        destination_address_prefix = "*"
+      }
+      "postgres_outbound" = {
+        name_override              = "postgres_outbound"
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "5432"
+        source_address_prefix      = "*"
         destination_address_prefix = "*"
       }
     }
@@ -269,6 +291,17 @@ network_security_groups = {
         destination_port_range     = "29418"
         source_address_prefix      = "*"
         destination_address_prefix = "10.88.128.192/27"
+      }
+      "postgres_outbound" = {
+        name_override              = "postgres_outbound"
+        priority                   = 100
+        direction                  = "Outbound"
+        access                     = "Deny"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "5432"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
       }
     }
   }

--- a/environments/nonprod/nonprod.tfvars
+++ b/environments/nonprod/nonprod.tfvars
@@ -130,7 +130,7 @@ network_security_groups = {
       }
       "postgres_outbound" = {
         name_override              = "postgres_outbound"
-        priority                   = 100
+        priority                   = 200
         direction                  = "Outbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -201,7 +201,7 @@ network_security_groups = {
       }
       "postgres_outbound" = {
         name_override              = "postgres_outbound"
-        priority                   = 100
+        priority                   = 200
         direction                  = "Outbound"
         access                     = "Allow"
         protocol                   = "Tcp"
@@ -294,7 +294,7 @@ network_security_groups = {
       }
       "postgres_outbound" = {
         name_override              = "postgres_outbound"
-        priority                   = 100
+        priority                   = 200
         direction                  = "Outbound"
         access                     = "Deny"
         protocol                   = "Tcp"


### PR DESCRIPTION
We have noticed that DB connection to the produtcion Atlassian database is open from any Azure services. this has recently caused problem on production jira, to stop the Staging VMs to be able to connect to the Atlassian prod database, we have added this rule which by default we going to set it to "deny" but going to change that to allow after updating the database connection string on all the restored database.