### PR TITLE
adding private end point for the the postgres server

### DIFF
--- a/components/general/db.tf
+++ b/components/general/db.tf
@@ -64,7 +64,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "postgres_dns_zone_vnet
   provider              = azurerm.dns
   name                  = "atlassian-${var.env}-postgres-dns-vnet-link"
   resource_group_name   = azurerm_resource_group.atlassian_rg.name
-  virtual_network_id    = module.networking.vnet_id
+  virtual_network_id    = module.networking.vnet_ids["atlassian-int-nonprod-vnet"]
   private_dns_zone_name = local.zone_name
 }
 

--- a/components/general/init.tf
+++ b/components/general/init.tf
@@ -15,3 +15,9 @@ provider "azurerm" {
   features {}
   subscription_id = var.subscription_id
 }
+
+provider "azurerm" {
+  alias = "dns"
+  features {}
+  subscription_id = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+}

--- a/environments/nonprod/nonprod.tfvars
+++ b/environments/nonprod/nonprod.tfvars
@@ -1,4 +1,3 @@
-
 environment     = "nonprod"
 subscription_id = "b7d2bd5f-b744-4acc-9c73-e068cec2e8d8"
 
@@ -19,6 +18,11 @@ vnets = {
       atlassian-int-subnet-app = {
         name_override     = "atlassian-int-subnet-app"
         address_prefixes  = ["10.0.4.192/26"]
+        service_endpoints = ["Microsoft.Sql"]
+      }
+      atlassian-int-subnet-postgres = {
+        name_override     = "atlassian-int-subnet-postgres"
+        address_prefixes  = ["10.0.4.0/26"]
         service_endpoints = ["Microsoft.Sql"]
       }
     }


### PR DESCRIPTION
This change will deploy private end point on the postgres single server and allow us to connect the private end point directly rather than going via internet.