### PR TITLE
DTSPO-23191 - adding missing private_dns_zone_id

### DIFF
--- a/components/general/db.tf
+++ b/components/general/db.tf
@@ -127,6 +127,7 @@ resource "azurerm_postgresql_flexible_server" "atlassian-flex-server" {
   resource_group_name = azurerm_resource_group.atlassian_rg.name
   sku_name            = var.flex_server_sku_name # Memory Optimized SKU
   delegated_subnet_id = module.networking.subnet_ids["atlassian-int-${var.env}-vnet-atlassian-int-subnet-postgres"]
+  private_dns_zone_id = local.private_dns_zone_id
 
   storage_mb        = var.flex_server_storage_mb #Closest alternative to previous 200GB on single server
   storage_tier      = var.flex_server_storage_tier


### PR DESCRIPTION
### Jira link

DTSPO-23191

### Change description

adding missing private_dns_zone_id property to resolve error "unexpected status 400 (400 Bad Request) with error: EmptyPrivateDnsZoneArmResourceId: The provided Private DNS zone ARM resource ID should not be empty for servers with Virtual Network access"

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
