### PR TITLE
DTSPO-24291 adding dynatrace extension non-prod

### DIFF
--- a/components/general/extensions.tf
+++ b/components/general/extensions.tf
@@ -20,6 +20,7 @@ module "vm-bootstrap" {
   os_type                     = var.os_type
   env                         = var.env == "prod" ? var.env : "nonprod"
   dynatrace_custom_hostname   = azurerm_virtual_machine.vm[each.key].name
+  dynatrace_hostgroup         = var.dynatrace_hostgroup
 
   common_tags = module.ctags.common_tags
   depends_on  = [azurerm_virtual_machine.vm]

--- a/components/general/extensions.tf
+++ b/components/general/extensions.tf
@@ -7,7 +7,7 @@ module "vm-bootstrap" {
     azurerm.soc = azurerm.soc
     azurerm.dcr = azurerm.dcr
   }
-  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=DTSPO-24291-updating-dynatrace-settings"
+  source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=master"
 
   virtual_machine_type        = "vm"
   virtual_machine_id          = azurerm_virtual_machine.vm[each.key].id

--- a/components/general/extensions.tf
+++ b/components/general/extensions.tf
@@ -1,6 +1,5 @@
 module "vm-bootstrap" {
-  #   for_each = var.install_dynatrace_oneagent ? var.vms : {}
-  count = var.env == "nonprod" ? 1 : 0
+  for_each = var.install_dynatrace_oneagent ? var.vms : {}
 
   providers = {
     azurerm     = azurerm
@@ -11,7 +10,7 @@ module "vm-bootstrap" {
   source = "git::https://github.com/hmcts/terraform-module-vm-bootstrap.git?ref=DTSPO-24291-updating-dynatrace-settings"
 
   virtual_machine_type        = "vm"
-  virtual_machine_id          = azurerm_virtual_machine.vm_test[count.index].id
+  virtual_machine_id          = azurerm_virtual_machine.vm[each.key].id
   install_dynatrace_oneagent  = var.install_dynatrace_oneagent
   install_azure_monitor       = var.install_azure_monitor
   install_nessus_agent        = var.install_nessus_agent
@@ -20,8 +19,8 @@ module "vm-bootstrap" {
   run_command                 = var.run_command
   os_type                     = var.os_type
   env                         = var.env == "prod" ? var.env : "nonprod"
-  dynatrace_custom_hostname   = azurerm_virtual_machine.vm_test[count.index].name
+  dynatrace_custom_hostname   = azurerm_virtual_machine.vm[each.key].name
 
   common_tags = module.ctags.common_tags
-  depends_on  = [azurerm_virtual_machine.vm_test]
+  depends_on  = [azurerm_virtual_machine.vm[each.key]]
 }

--- a/components/general/extensions.tf
+++ b/components/general/extensions.tf
@@ -22,5 +22,5 @@ module "vm-bootstrap" {
   dynatrace_custom_hostname   = azurerm_virtual_machine.vm[each.key].name
 
   common_tags = module.ctags.common_tags
-  depends_on  = [azurerm_virtual_machine.vm[each.key]]
+  depends_on  = [azurerm_virtual_machine.vm]
 }

--- a/components/general/vm-nic.tf
+++ b/components/general/vm-nic.tf
@@ -17,18 +17,3 @@ resource "azurerm_network_interface" "nic" {
 
   tags = module.ctags.common_tags
 }
-
-resource "azurerm_network_interface" "nic_test" {
-  count               = var.env == "nonprod" ? 1 : 0
-  name                = "atlassian_nonprod_test_nic"
-  location            = "UK South"
-  resource_group_name = azurerm_resource_group.atlassian_rg.name
-  ip_configuration {
-    name = "atlassian_nonprod_test"
-
-    subnet_id                     = module.networking.subnet_ids["atlassian-int-nonprod-vnet-atlassian-int-subnet-app"]
-    private_ip_address_allocation = "Static"
-    private_ip_address            = "10.0.4.202"
-  }
-  tags = module.ctags.common_tags
-}

--- a/components/general/vm.tf
+++ b/components/general/vm.tf
@@ -26,26 +26,6 @@ resource "azurerm_virtual_machine" "vm" {
   tags = module.ctags.common_tags
 }
 
-resource "azurerm_virtual_machine" "vm_test" {
-  count                        = var.env == "nonprod" ? 1 : 0
-  name                         = "atlassian_nonprod_test_vm"
-  location                     = "UK South"
-  resource_group_name          = azurerm_resource_group.atlassian_rg.name
-  vm_size                      = "Standard_E8s_v3"
-  network_interface_ids        = [azurerm_network_interface.nic_test[count.index].id]
-  primary_network_interface_id = azurerm_network_interface.nic_test[count.index].id
-
-  storage_os_disk {
-    name              = "atlassian_test_disk"
-    caching           = "ReadOnly"
-    create_option     = "Attach"
-    managed_disk_type = "Premium_LRS"
-    os_type           = "Linux"
-  }
-
-  tags = module.ctags.common_tags
-}
-
 resource "azurerm_virtual_machine_data_disk_attachment" "data_disk_attachment" {
   for_each = var.data_disks
 


### PR DESCRIPTION
### Jira link

[DTSPO-24291](https://tools.hmcts.net/jira/browse/DTSPO-24291)


### Change description

adding bootstrap module to install dynatrace extension on non-prod atlassian vm's

Tested by installing extension onto one vm (see image)

<img width="1209" alt="Screenshot 2025-03-04 at 12 18 17" src="https://github.com/user-attachments/assets/ece44aef-3835-4f13-ae23-661f16e47f53" />
