### PR TITLE
DTSPO-24311 - Temp disassociate VMs from backup policies

### DIFF
--- a/components/general/backups.tf
+++ b/components/general/backups.tf
@@ -49,10 +49,10 @@ resource "azurerm_backup_policy_vm" "vm-backup-policy" {
   }
 }
 
-resource "azurerm_backup_protected_vm" "vm-backup" {
-  for_each            = { for k, v in var.vms : k => v if var.env == "prod" }
-  resource_group_name = azurerm_resource_group.atlassian_rg.name
-  recovery_vault_name = azurerm_recovery_services_vault.rsv[0].name
-  source_vm_id        = azurerm_virtual_machine.vm[each.key].id
-  backup_policy_id    = azurerm_backup_policy_vm.vm-backup-policy[0].id
-}
+# resource "azurerm_backup_protected_vm" "vm-backup" {
+#   for_each            = { for k, v in var.vms : k => v if var.env == "prod" }
+#   resource_group_name = azurerm_resource_group.atlassian_rg.name
+#   recovery_vault_name = azurerm_recovery_services_vault.rsv[0].name
+#   source_vm_id        = azurerm_virtual_machine.vm[each.key].id
+#   backup_policy_id    = azurerm_backup_policy_vm.vm-backup-policy[0].id
+# }


### PR DESCRIPTION
### Jira link

See [DTSPO-24311](https://tools.hmcts.net/jira/browse/DTSPO-24311)

### Change description

Disassociate VMs from backup policy temporarily
VMs will be deleted tonight and restored fresh overnight in prep for the migration
VMs will be readded to the policy once the new prod environment is completely migrated

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
