### PR TITLE
DTSPO-24225 -Enabling backups in prod

### DIFF
--- a/components/general/backups.tf
+++ b/components/general/backups.tf
@@ -48,6 +48,7 @@ resource "azurerm_backup_policy_vm" "vm-backup-policy" {
 }
 
 resource "azurerm_backup_protected_vm" "vm-backup" {
+  for_each            = { for k, v in var.vms : k => v }
   resource_group_name = azurerm_resource_group.atlassian_rg.name
   recovery_vault_name = azurerm_recovery_services_vault.rsv.name
   source_vm_id        = azurerm_virtual_machine.vm[each.key].id

--- a/components/general/backups.tf
+++ b/components/general/backups.tf
@@ -47,9 +47,9 @@ resource "azurerm_backup_policy_vm" "vm-backup-policy" {
   }
 }
 
-# resource "azurerm_backup_protected_vm" "vm-backup" {
-#   resource_group_name = azurerm_resource_group.atlassian_rg.name
-#   recovery_vault_name = azurerm_recovery_services_vault.rsv.name
-#   source_vm_id        = azurerm_virtual_machine.vm[each.key].id
-#   backup_policy_id    = azurerm_backup_policy_vm.vm-backup-policy.id
-# }
+resource "azurerm_backup_protected_vm" "vm-backup" {
+  resource_group_name = azurerm_resource_group.atlassian_rg.name
+  recovery_vault_name = azurerm_recovery_services_vault.rsv.name
+  source_vm_id        = azurerm_virtual_machine.vm[each.key].id
+  backup_policy_id    = azurerm_backup_policy_vm.vm-backup-policy.id
+}

--- a/components/general/vm.tf
+++ b/components/general/vm.tf
@@ -19,12 +19,30 @@ resource "azurerm_virtual_machine" "vm" {
   storage_os_disk {
     name              = each.value.os_disk_name
     caching           = "ReadOnly"
-    create_option     = "FromImage"
+    create_option     = "Attach"
     managed_disk_type = "Premium_LRS"
   }
 
+  tags = module.ctags.common_tags
+}
+
+resource "azurerm_virtual_machine" "vm_test" {
+  count                        = var.env == "nonprod" ? 1 : 0
+  name                         = "atlassian_nonprod_test_vm"
+  location                     = "UK South"
+  resource_group_name          = azurerm_resource_group.atlassian_rg.name
+  vm_size                      = "Standard_E8s_v3"
+  network_interface_ids        = [azurerm_network_interface.nic_test[count.index].id]
+  primary_network_interface_id = azurerm_network_interface.nic_test[count.index].id
+
   storage_image_reference {
     id = "RedHat:RHEL:7.8:7.8.2021051701"
+  }
+  storage_os_disk {
+    name              = "atlassiannonprodjira01-osdisk-20250224-221942"
+    caching           = "ReadOnly"
+    create_option     = "FromImage"
+    managed_disk_type = "Premium_LRS"
   }
 
   tags = module.ctags.common_tags

--- a/components/general/vm.tf
+++ b/components/general/vm.tf
@@ -26,28 +26,6 @@ resource "azurerm_virtual_machine" "vm" {
   tags = module.ctags.common_tags
 }
 
-resource "azurerm_virtual_machine" "vm_test" {
-  count                        = var.env == "nonprod" ? 1 : 0
-  name                         = "atlassian_nonprod_test_vm"
-  location                     = "UK South"
-  resource_group_name          = azurerm_resource_group.atlassian_rg.name
-  vm_size                      = "Standard_E8s_v3"
-  network_interface_ids        = [azurerm_network_interface.nic_test[count.index].id]
-  primary_network_interface_id = azurerm_network_interface.nic_test[count.index].id
-
-  storage_image_reference {
-    id = "RedHat:RHEL:7.8:7.8.2021051701"
-  }
-  storage_os_disk {
-    name              = "atlassiannonprodjira01-osdisk-20250224-221942"
-    caching           = "ReadOnly"
-    create_option     = "FromImage"
-    managed_disk_type = "Premium_LRS"
-  }
-
-  tags = module.ctags.common_tags
-}
-
 resource "azurerm_virtual_machine_data_disk_attachment" "data_disk_attachment" {
   for_each = var.data_disks
 

--- a/components/general/vm.tf
+++ b/components/general/vm.tf
@@ -19,8 +19,12 @@ resource "azurerm_virtual_machine" "vm" {
   storage_os_disk {
     name              = each.value.os_disk_name
     caching           = "ReadOnly"
-    create_option     = "Attach"
+    create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
+  }
+
+  storage_image_reference {
+    id = "RedHat:RHEL:7.8:7.8.2021051701"
   }
 
   tags = module.ctags.common_tags


### PR DESCRIPTION
### Jira link

DTSPO-24225

### Change description

Following successful restores in production, this PR will add these new VM's to the backup policy.

### Testing done

Tested in staging.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
