### PR TITLE
Import vm extensions into non-prod

### DIFF
--- a/components/general/extensions.tf
+++ b/components/general/extensions.tf
@@ -1,3 +1,9 @@
+import {
+  for_each = var.env == "nonprod" ? var.vms : {}
+  to       = module.vm-bootstrap[each.key].azurerm_virtual_machine_extension.custom_script[0]
+  id       = "/subscriptions/b7d2bd5f-b744-4acc-9c73-e068cec2e8d8/resourceGroups/atlassian-nonprod-rg/providers/Microsoft.Compute/virtualMachines/${each.key}/extensions/HMCTSVMBootstrap"
+}
+
 module "vm-bootstrap" {
   for_each = var.install_dynatrace_oneagent ? var.vms : {}
 


### PR DESCRIPTION
### Jira link


### Change description
Previous merge has failed: https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=811701&view=logs&j=972fdc6b-e075-5228-ef85-c1306ebc07f0&t=b392e54b-70b0-54a2-7abc-60561a4a08fe  
So import vm extensions into non-prod as they exist but are missing from the state

### Testing done
TF plan in checks

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
